### PR TITLE
Lengthen and document power-off delay for car system

### DIFF
--- a/arduino/src/car_system/car_system.ino
+++ b/arduino/src/car_system/car_system.ino
@@ -93,7 +93,12 @@ void loop() {
   // Power on/off
   if(!powerOn) {
     digitalWrite(pinPowerLED, LOW);
-    delay(3 * 1000);  // 3 seconds in addition to the 3 second delay
+
+    // 5 minutes
+    // 60 seconds per minute
+    // 1000 milliseconds per second
+    delay(5 * 60 * 1000);
+
     powerOn = true;
   }
   else {

--- a/arduino/src/car_system/car_system.ino
+++ b/arduino/src/car_system/car_system.ino
@@ -4,6 +4,9 @@
  * to whether or not the sensor systems are activated, and alerts the user if
  * a user is present and the sensors return the presence of an item.
  *
+ * If the power button is pressed while the system is alerting the user,
+ * the system turns off for several minutes before re-activating.
+ *
  */
 
 #include <avr/pgmspace.h>
@@ -94,6 +97,7 @@ void loop() {
   if(!powerOn) {
     digitalWrite(pinPowerLED, LOW);
 
+    // Turn off temporarily when power button is pressed while alert is active
     // 5 minutes
     // 60 seconds per minute
     // 1000 milliseconds per second


### PR DESCRIPTION
As addressed in [this issue](https://github.com/jleung51/BIRD/issues/24).

For practicality and demonstration purposes during development, we set the power-off delay to 3 seconds here in the code; this has been lengthened to a realistic delay of 5+ minutes.
